### PR TITLE
Remove NIH API Disclaimers from page footer

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -5,18 +5,20 @@ const Footer = () => {
     <div>
       <p className="mb-10" id="page-divider"></p>
       <p id="footer-text">Copyright 2023 Lynn Jansheski</p>
-      <p id="footer-text">
+      {/* Removing NIH API disclaimers for now. Drug interaction api deprecated. 
+      TODO: Replace with human/vet drug classification */}
+      {/* <p id="footer-text">
         "This product uses publicly available data from the U.S. National
         Library of Medicine (NLM), National Institutes of Health, Department of
         Health and Human Services; NLM is not responsible for the product and
         does not endorse or recommend this or any other product."
-      </p>
-      <cite id="footer-text">
+      </p> */}
+      {/* <cite id="footer-text">
         Citing DrugBank: Wishart DS, Knox C, Guo AC, Shrivastava S, Hassanali M,
         Stothard P, Chang Z, Woolsey J. DrugBank: a comprehensive resource for
         in silico drug discovery and exploration. Nucleic Acids Res. 2006 Jan
         1;34(Database issue):D668-72. 16381955
-      </cite>
+      </cite> */}
     </div>
   );
 };


### PR DESCRIPTION
**Objective:**
The drug interactions api was deprecated in Feb 2024. Removing disclaimers.

**Test Plan**
Checked local UI. Footer text removed as expected